### PR TITLE
Detecção de duplicidade de princípio ativo

### DIFF
--- a/interface-react/src/Pages/PaginaCadastro/CadastroMedicamentos.jsx
+++ b/interface-react/src/Pages/PaginaCadastro/CadastroMedicamentos.jsx
@@ -3,7 +3,7 @@ import {useNavigate, useParams} from "react-router-dom";
 import api, { BACKEND_URL } from "../../Service/api";
 import {getUserInfo, getUserRole} from "../../Componentes/Auth/AuthToken";
 import useMedicamentos from "../../Componentes/ListaDeMed";
-import { FiImage, FiUpload } from "react-icons/fi";
+import { FiAlertTriangle, FiCheckCircle, FiImage, FiUpload, FiX } from "react-icons/fi";
 
 const CadastroMedicamentos = () => {
     const userRole = getUserRole();
@@ -12,6 +12,8 @@ const CadastroMedicamentos = () => {
     const { buscarAgenteAtivo, filtrarMedicamentos } = useMedicamentos();
     const [sugestoes, setSugestoes] = useState([]);
     const [mostrarSugestoes, setMostrarSugestoes] = useState(false);
+    const [duplicidade, setDuplicidade] = useState(null);
+    const [salvando, setSalvando] = useState(false);
     
     const [formData, setFormData] = useState({
         nome: "",
@@ -270,7 +272,7 @@ const CadastroMedicamentos = () => {
         return extras;
     }, [formData.frequenciaUso]);
 
-    const getDadosCadastro = (userRole) => {
+    const getDadosCadastro = (userRole, opcoes = {}) => {
         const temEstoque = formData.estoque.quantidadeAtual !== "";
         const dadosEstoque = temEstoque ? {
             quantidadeAtual: Number(formData.estoque.quantidadeAtual),
@@ -284,6 +286,7 @@ const CadastroMedicamentos = () => {
             observacoes: formData.observacoes,
             usuarioId: usuarioId,
             estoque: dadosEstoque,
+            ignorarDuplicidade: opcoes.ignorarDuplicidade || false,
             frequenciaUso: {
                 frequenciaUsoTipo: formData.frequenciaUso.frequenciaUsoTipo,
                 usoContinuo: formData.frequenciaUso.usoContinuo,
@@ -300,16 +303,19 @@ const CadastroMedicamentos = () => {
             : dadosBase;
     };
 
-    const handleSubmit = async (e) => {
-        e.preventDefault();
-
+    const cadastrarMedicamento = async ({ ignorarDuplicidade = false } = {}) => {
         if (!formData.nome || !formData.principioAtivo || !formData.dosagemQuantidade || !formData.dosagemUnidade) {
             alert('Por favor, preencha todos os campos obrigatórios.');
             return;
         }
 
+        setSalvando(true);
+
         try {
-            const response = await api.post(`${BACKEND_URL}/medicamentos/cadastro`, getDadosCadastro(userRole));
+            const response = await api.post(
+                `${BACKEND_URL}/medicamentos/cadastro`,
+                getDadosCadastro(userRole, { ignorarDuplicidade })
+            );
             if (response) {
                 if (formData.imagemArquivo && response.id) {
                     const dadosImagem = new FormData();
@@ -324,8 +330,26 @@ const CadastroMedicamentos = () => {
             }
         } catch (error) {
             console.error('Erro ao cadastrar medicamento:', error);
+
+            if (error.status === 409 && error.data?.duplicidade) {
+                setDuplicidade(error.data);
+                return;
+            }
+
             alert('Erro ao cadastrar medicamento. Verifique sua conexão ou tente novamente mais tarde.');
+        } finally {
+            setSalvando(false);
         }
+    };
+
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+        await cadastrarMedicamento();
+    };
+
+    const continuarComDuplicidade = async () => {
+        setDuplicidade(null);
+        await cadastrarMedicamento({ ignorarDuplicidade: true });
     };
 
     const getValorCampo = (nomeCampo) => {
@@ -333,8 +357,6 @@ const CadastroMedicamentos = () => {
         if (nomeCampo in formData.estoque) return formData.estoque[nomeCampo] || "";
         return formData[nomeCampo] || "";
     };   
-
-    console.log("Campos renderizados:", [...camposBase, ...camposExtras].map(c => c.id));
 
     return (
         <div className="flex flex-col items-center justify-center min-h-screen">
@@ -506,9 +528,10 @@ const CadastroMedicamentos = () => {
                 <div className="flex justify-end gap-2 mt-6">
                     <button
                         type="submit"
-                        className="bg-blue-500 text-white px-4 py-2 rounded-lg hover:bg-blue-600"
+                        disabled={salvando}
+                        className="bg-blue-500 text-white px-4 py-2 rounded-lg hover:bg-blue-600 disabled:cursor-not-allowed disabled:bg-blue-300"
                     >
-                        Salvar
+                        {salvando ? "Salvando..." : "Salvar"}
                     </button>
                     <button
                         type="button"
@@ -519,6 +542,62 @@ const CadastroMedicamentos = () => {
                     </button>
                 </div>
             </form>
+
+            {duplicidade && (
+                <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4">
+                    <div className="w-full max-w-md rounded-lg bg-white p-6 shadow-xl">
+                        <div className="flex items-start gap-3">
+                            <span className="flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-full bg-amber-100 text-amber-600">
+                                <FiAlertTriangle size={24} />
+                            </span>
+                            <div>
+                                <h2 className="text-lg font-semibold text-gray-900">
+                                    Possível duplicidade de princípio ativo
+                                </h2>
+                                <p className="mt-2 text-sm text-gray-600">
+                                    {duplicidade.mensagem}
+                                </p>
+                            </div>
+                        </div>
+
+                        <div className="mt-5 rounded-lg border border-amber-200 bg-amber-50 p-4">
+                            <p className="text-sm text-gray-700">
+                                Medicamento já cadastrado:
+                            </p>
+                            <p className="mt-1 font-semibold text-gray-900">
+                                {duplicidade.nomeMedicamentoExistente}
+                            </p>
+                            <p className="mt-1 text-sm text-gray-600">
+                                Princípio ativo: {duplicidade.principioAtivoConflitante}
+                            </p>
+                        </div>
+
+                        <p className="mt-4 text-sm text-gray-600">
+                            Verifique se há risco de uso simultâneo antes de continuar.
+                        </p>
+
+                        <div className="mt-6 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+                            <button
+                                type="button"
+                                onClick={() => setDuplicidade(null)}
+                                className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-300 px-4 py-2 text-gray-700 hover:bg-gray-50"
+                            >
+                                <FiX size={18} />
+                                Cancelar cadastro
+                            </button>
+                            <button
+                                type="button"
+                                onClick={continuarComDuplicidade}
+                                disabled={salvando}
+                                className="inline-flex items-center justify-center gap-2 rounded-lg bg-amber-500 px-4 py-2 text-white hover:bg-amber-600 disabled:cursor-not-allowed disabled:bg-amber-300"
+                            >
+                                <FiCheckCircle size={18} />
+                                Continuar mesmo assim
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            )}
         </div>
     );
 };

--- a/interface-react/src/Service/api.js
+++ b/interface-react/src/Service/api.js
@@ -16,6 +16,43 @@ const parseErrorResponse = async (response) => {
     return text || response.statusText;
 };
 
+const parseResponseBody = async (response) => {
+    const text = await response.text();
+    if (!text) {
+        return true;
+    }
+
+    try {
+        return JSON.parse(text);
+    } catch {
+        return text;
+    }
+};
+
+const getErrorMessage = (errorData, fallbackMessage) => {
+    if (Array.isArray(errorData)) {
+        return errorData.map((item) => item.mensagem || item.message).filter(Boolean).join(' ') || fallbackMessage;
+    }
+
+    if (typeof errorData === 'string') {
+        return errorData;
+    }
+
+    return errorData?.message || errorData?.mensagem || fallbackMessage;
+};
+
+const createApiError = (response, errorData, fallbackMessage = 'Erro ao fazer a requisição') => {
+    const error = new Error(getErrorMessage(errorData, fallbackMessage));
+    error.status = response.status;
+    error.data = errorData;
+
+    if (Array.isArray(errorData)) {
+        error.details = errorData;
+    }
+
+    return error;
+};
+
 const api  = {
 
     get: async (url) => {
@@ -28,11 +65,11 @@ const api  = {
             });
 
             if (!response.ok) {
-                const errorData = await response.json(); // Tenta obter detalhes do erro
-                throw new Error(errorData.message || "Erro ao buscar dados");
+                const errorData = await parseErrorResponse(response);
+                throw createApiError(response, errorData, "Erro ao buscar dados");
             }
 
-            return response.json();
+            return parseResponseBody(response);
         } catch (error) {
             console.error("Erro na requisição GET:", error);
             throw error; // Propaga o erro para ser tratado no componente
@@ -51,17 +88,10 @@ const api  = {
 
         if (!response.ok) {
             const errorData = await parseErrorResponse(response);
-            if (response.status === 400 && Array.isArray(errorData)) {
-                const validationMessage = errorData.map((item) => item.mensagem).join(' ');
-                const error = new Error(validationMessage || 'Erro ao fazer a requisição');
-                error.details = errorData;
-                throw error;
-            }
-            throw new Error(typeof errorData === 'string' ? errorData : errorData?.message || 'Erro ao fazer a requisição');
+            throw createApiError(response, errorData);
         }
 
-        const text = await response.text();
-        return text ? JSON.parse(text) : true;
+        return parseResponseBody(response);
 
     },
 
@@ -76,16 +106,10 @@ const api  = {
 
         if (!response.ok) {
             const errorData = await parseErrorResponse(response);
-            if (response.status === 400 && Array.isArray(errorData)) {
-                const error = new Error(errorData.map((item) => item.mensagem).join(' ') || 'Erro ao fazer a requisição');
-                error.details = errorData;
-                throw error;
-            }
-            throw new Error(typeof errorData === 'string' ? errorData : errorData?.message || 'Erro ao fazer a requisição');
+            throw createApiError(response, errorData);
         }
 
-        const text = await response.text();
-        return text ? JSON.parse(text) : true;
+        return parseResponseBody(response);
 
     },
 
@@ -101,16 +125,10 @@ const api  = {
 
         if (!response.ok) {
             const errorData = await parseErrorResponse(response);
-            if (response.status === 400 && Array.isArray(errorData)) {
-                const error = new Error(errorData.map((item) => item.mensagem).join(' ') || 'Erro ao fazer a requisição');
-                error.details = errorData;
-                throw error;
-            }
-            throw new Error(typeof errorData === 'string' ? errorData : errorData?.message || 'Erro ao fazer a requisição');
+            throw createApiError(response, errorData);
         }
 
-        const text = await response.text();
-        return text ? JSON.parse(text) : true;
+        return parseResponseBody(response);
     },
 
     patch: async (url, data) => {
@@ -125,16 +143,10 @@ const api  = {
 
         if (!response.ok) {
             const errorData = await parseErrorResponse(response);
-            if (response.status === 400 && Array.isArray(errorData)) {
-                const error = new Error(errorData.map((item) => item.mensagem).join(' ') || 'Erro ao fazer a requisição');
-                error.details = errorData;
-                throw error;
-            }
-            throw new Error(typeof errorData === 'string' ? errorData : errorData?.message || 'Erro ao fazer a requisição');
+            throw createApiError(response, errorData);
         }
 
-        const text = await response.text();
-        return text ? JSON.parse(text) : true;
+        return parseResponseBody(response);
     },
 
     delete: async (url) => {
@@ -147,7 +159,8 @@ const api  = {
         });
 
         if (response.status !== 204) {
-            throw new Error('Erro ao fazer a requisição');
+            const errorData = await parseErrorResponse(response);
+            throw createApiError(response, errorData);
         }
         return true
     }

--- a/src/main/java/com/medtrack/medtrack/controller/MedicamentoController.java
+++ b/src/main/java/com/medtrack/medtrack/controller/MedicamentoController.java
@@ -8,6 +8,7 @@ import com.medtrack.medtrack.model.usuario.dto.DadosDashboardPessoal;
 import com.medtrack.medtrack.model.medicamento.dto.DadosMedicamentoPut;
 import com.medtrack.medtrack.repository.MedicamentoRepository;
 import com.medtrack.medtrack.service.CloudinaryService;
+import com.medtrack.medtrack.service.medicamento.DuplicidadeMedicamentoException;
 import com.medtrack.medtrack.service.medicamento.MedicamentoService;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.transaction.Transactional;
@@ -39,10 +40,15 @@ public class MedicamentoController {
     }
 
     @PostMapping("/cadastro")
-    @Transactional
-    public ResponseEntity<DadosMedicamentoGet> create(@RequestBody @Valid DadosMedicamento dadosMedicamento) {
+    public ResponseEntity<?> create(@RequestBody @Valid DadosMedicamento dadosMedicamento) {
         logger.info("Recebendo requisição para criar medicamento: {}", dadosMedicamento);
-        Medicamento medicamento = medicamentoService.criarMedicamento(dadosMedicamento);
+        Medicamento medicamento;
+
+        try {
+            medicamento = medicamentoService.criarMedicamento(dadosMedicamento);
+        } catch (DuplicidadeMedicamentoException e) {
+            return ResponseEntity.status(409).body(e.getDadosDuplicidade());
+        }
 
         URI uri = ServletUriComponentsBuilder.fromCurrentRequest()
                 .path("/{id}")

--- a/src/main/java/com/medtrack/medtrack/model/medicamento/dto/DadosDuplicidadeMedicamento.java
+++ b/src/main/java/com/medtrack/medtrack/model/medicamento/dto/DadosDuplicidadeMedicamento.java
@@ -1,0 +1,22 @@
+package com.medtrack.medtrack.model.medicamento.dto;
+
+import com.medtrack.medtrack.model.medicamento.Medicamento;
+
+public record DadosDuplicidadeMedicamento(
+        boolean duplicidade,
+        Long medicamentoExistenteId,
+        String principioAtivoConflitante,
+        String nomeMedicamentoExistente,
+        String mensagem
+) {
+    public DadosDuplicidadeMedicamento(Medicamento medicamento) {
+        this(
+                true,
+                medicamento.getId(),
+                medicamento.getPrincipioAtivo(),
+                medicamento.getNome(),
+                "JÁ existe um medicamento cadastrado com o mesmo principio ativo. " +
+                        "Verifique se ha risco de duplicidade antes de continuar."
+        );
+    }
+}

--- a/src/main/java/com/medtrack/medtrack/model/medicamento/dto/DadosMedicamento.java
+++ b/src/main/java/com/medtrack/medtrack/model/medicamento/dto/DadosMedicamento.java
@@ -28,7 +28,9 @@ public record DadosMedicamento(
         DadosFrequenciaUso frequenciaUso,
 
         @Valid
-        DadosEstoque estoque
+        DadosEstoque estoque,
+
+        Boolean ignorarDuplicidade
 
 ) {
 

--- a/src/main/java/com/medtrack/medtrack/repository/MedicamentoRepository.java
+++ b/src/main/java/com/medtrack/medtrack/repository/MedicamentoRepository.java
@@ -10,6 +10,7 @@ import java.util.List;
 public interface MedicamentoRepository extends JpaRepository<Medicamento, Long> {
     List<Medicamento> findByDependenteId(Long dependenteId);
     List<Medicamento> findByUsuarioId(Long usuarioId);
+    List<Medicamento> findByUsuarioIdAndDependenteIsNull(Long usuarioId);
 
     @Query("SELECT m FROM Medicamento m JOIN m.estoque e WHERE m.usuario.id = :usuarioId AND e.quantidadeAtual <= e.quantidadeMinima")
     List<Medicamento> findEstoqueBaixoByUsuarioId(@Param("usuarioId") Long usuarioId);

--- a/src/main/java/com/medtrack/medtrack/service/medicamento/DuplicidadeMedicamentoException.java
+++ b/src/main/java/com/medtrack/medtrack/service/medicamento/DuplicidadeMedicamentoException.java
@@ -1,0 +1,16 @@
+package com.medtrack.medtrack.service.medicamento;
+
+import com.medtrack.medtrack.model.medicamento.dto.DadosDuplicidadeMedicamento;
+import lombok.Getter;
+
+@Getter
+public class DuplicidadeMedicamentoException extends RuntimeException {
+
+    private final DadosDuplicidadeMedicamento dadosDuplicidade;
+
+    public DuplicidadeMedicamentoException(DadosDuplicidadeMedicamento dadosDuplicidade) {
+        super(dadosDuplicidade.mensagem());
+        this.dadosDuplicidade = dadosDuplicidade;
+    }
+
+}

--- a/src/main/java/com/medtrack/medtrack/service/medicamento/MedicamentoService.java
+++ b/src/main/java/com/medtrack/medtrack/service/medicamento/MedicamentoService.java
@@ -3,6 +3,7 @@ package com.medtrack.medtrack.service.medicamento;
 import com.medtrack.medtrack.model.dependente.Dependente;
 import com.medtrack.medtrack.model.medicamento.FrequenciaUso;
 import com.medtrack.medtrack.model.medicamento.Medicamento;
+import com.medtrack.medtrack.model.medicamento.dto.DadosDuplicidadeMedicamento;
 import com.medtrack.medtrack.model.medicamento.dto.DadosMedicamento;
 import com.medtrack.medtrack.model.medicamento.dto.DadosMedicamentoGet;
 import com.medtrack.medtrack.model.medicamento.dto.DadosMedicamentoPut;
@@ -12,6 +13,7 @@ import com.medtrack.medtrack.repository.DependenteRepository;
 import com.medtrack.medtrack.repository.FrequenciaUsoRepository;
 import com.medtrack.medtrack.repository.MedicamentoRepository;
 import com.medtrack.medtrack.repository.UsuarioRepository;
+import com.medtrack.medtrack.util.NormalizeString;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.transaction.Transactional;
 import org.springframework.stereotype.Service;
@@ -60,6 +62,8 @@ public class MedicamentoService {
                     .orElseThrow(() -> new IllegalArgumentException("Dependente não encontrado"));
         }
 
+        verificarDuplicidadePrincipioAtivo(dadosMedicamento);
+
         FrequenciaUso frequenciaUso = dadosMedicamento.frequenciaUso().id() != null
                 ? frequenciaUsoRepository.findById(dadosMedicamento.frequenciaUso().id())
                 .orElseThrow(() -> new IllegalArgumentException("Frequência de uso não encontrada"))
@@ -69,6 +73,30 @@ public class MedicamentoService {
         medicamento.setFrequenciaUso(frequenciaUso);
 
         return medicamentoRepository.save(medicamento);
+    }
+
+    private void verificarDuplicidadePrincipioAtivo(DadosMedicamento dadosMedicamento) {
+        if (Boolean.TRUE.equals(dadosMedicamento.ignorarDuplicidade())) {
+            return;
+        }
+
+        String principioAtivoNormalizado = NormalizeString.normalize(dadosMedicamento.principioAtivo());
+        if (principioAtivoNormalizado.isBlank()) {
+            return;
+        }
+
+        List<Medicamento> medicamentosDoContexto = dadosMedicamento.dependenteId() != null
+                ? medicamentoRepository.findByDependenteId(dadosMedicamento.dependenteId())
+                : medicamentoRepository.findByUsuarioIdAndDependenteIsNull(dadosMedicamento.usuarioId());
+
+        medicamentosDoContexto.stream()
+                .filter(medicamento -> principioAtivoNormalizado.equals(
+                        NormalizeString.normalize(medicamento.getPrincipioAtivo())
+                ))
+                .findFirst()
+                .ifPresent(medicamento -> {
+                    throw new DuplicidadeMedicamentoException(new DadosDuplicidadeMedicamento(medicamento));
+                });
     }
 
     public void atualizarMedicamento(DadosMedicamentoPut dadosMedicamentoPut, Long id) {

--- a/src/main/java/com/medtrack/medtrack/util/NormalizeString.java
+++ b/src/main/java/com/medtrack/medtrack/util/NormalizeString.java
@@ -1,0 +1,23 @@
+package com.medtrack.medtrack.util;
+
+import java.text.Normalizer;
+
+public final class NormalizeString {
+
+    private NormalizeString() {
+    }
+
+    public static String normalize(String value) {
+        if (value == null) {
+            return "";
+        }
+
+        String withoutAccents = Normalizer.normalize(value, Normalizer.Form.NFD)
+                .replaceAll("\\p{M}", "");
+
+        return withoutAccents
+                .trim()
+                .replaceAll("\\s+", " ")
+                .toLowerCase();
+    }
+}


### PR DESCRIPTION
> [!IMPORTANT]
>## Ajuste pós-rebase

- Resolvido conflito em `interface-react/src/Service/api.js`.
- Centralizado o tratamento de respostas e erros da API.
- Preservados `status`, `data` e `details` nos erros lançados pelo client HTTP.
- Mantida a compatibilidade com o fluxo de duplicidade de princípio ativo (`409 Conflict`), permitindo que o frontend exiba o modal com os dados retornados pelo backend.
- Validado com `npm.cmd run build`.


# Descrição Inicial

Esta PR adiciona a detecção de ingredientes ativos duplicados durante o registro de medicamentos, a fim de reduzir os riscos relacionados à duplicação terapêutica relatados durante entrevistas com as partes interessadas.

### Backend

Adicionada detecção de duplicados baseada em `principioAtivo`
Comparação normalizada ignorando:
- diferenças entre maiúsculas e minúsculas
- acentos
- espaços extras

Validação de duplicados com escopo correto:
- medicamentos pessoais são comparados apenas com medicamentos pessoais do mesmo usuário
- medicamentos dependentes são comparados apenas com medicamentos do mesmo dependente

Adicionado DTO de conflito dedicado em vez de expor entidades JPA
Retorna `409 Conflict` quando um duplicado é detectado
Permite continuação explícita usando `ignorarDuplicidade: true`

### Frontend

Adicionado modal de aviso durante o cadastro de medicamentos
Exibe:
- medicamento conflitante
- princípio ativo duplicado

Permite ao usuário:
- cancelar o cadastro
- continuar explicitamente
Atualizado `api.post` para preservar o corpo da resposta de erro do backend necessário para o tratamento do erro 409

<img width="1019" height="911" alt="Captura de tela 2026-05-25 222309" src="https://github.com/user-attachments/assets/05145d80-d7ad-470c-b0a1-aea1b3709eeb" />

### Correções

Corrigido um problema causado por `@Transactional` em `MedicamentoController.create()`.

A anotação de transação foi removida do endpoint do controlador, pois o gerenciamento de transações já existe em `MedicamentoService.criarMedicamento`.

Ou seja, havia `@Transactional` tanto no MedicamentoController.java quanto no MedicamentoService.java na função de criar medicamento, causando `UnexpectedRollbackException` cando o controllador retornava `409 Conflict`.


Closes #86